### PR TITLE
Eliminate warning due to inactive Comments plugin (now default)

### DIFF
--- a/Plugin/Nodes/Nodes/view.ctp
+++ b/Plugin/Nodes/Nodes/view.ctp
@@ -8,16 +8,18 @@
 	?>
 </div>
 
+<?php if (CakePlugin::loaded('Comments')): ?>
 <div id="comments" class="node-comments">
 <?php
 	$type = $types_for_layout[$this->Nodes->field('type')];
 
 	if ($type['Type']['comment_status'] > 0 && $this->Nodes->field('comment_status') > 0) {
-		echo $this->element('Comments.comments');
+		echo $this->element('Comments.comments', array('model' => 'Node', 'data' => $node));
 	}
 
 	if ($type['Type']['comment_status'] == 2 && $this->Nodes->field('comment_status') == 2) {
-		echo $this->element('Comments.comments_form');
+		echo $this->element('Comments.comments_form', array('model' => 'Node', 'data' => $node));
 	}
 ?>
 </div>
+<?php endif; ?>


### PR DESCRIPTION
Since your release, the Comments plugin has been set to inactive after a fresh Croogo install. This PR incorporates a change that was made to the core Nodes plugin template to accomodate the change in the install.

Actually, I believe you could delete this file entirely because it does not differ from the core view.ctp file (because it does not contain any custom pagination as do your other templates in this directory). However, I'll let you do that rather than me pushing a delete.

Thanks for your work!
