### PR TITLE
Correct search element for recent form security changes

### DIFF
--- a/Plugin/Nodes/Elements/search.ctp
+++ b/Plugin/Nodes/Elements/search.ctp
@@ -1,41 +1,18 @@
 <?php
-	$b = $block['Block'];
-	$class = 'block block-' . $b['alias'];
-	if ($block['Block']['class'] != null) {
-		$class .= ' ' . $b['class'];
-	}
+	echo $this->Form->create('Node', array('url' => array('admin' => false, 'plugin' => 'nodes', 'controller' => 'nodes', 'action' => 'search', 'class' => 'form-search')));
+	$this->Form->unlockField('q');
+	echo $this->Form->input('q', array(
+		'label' => false,
+		'class' => 'form-control',
+		'placeholder' => __('Search'),
+		'div' => 'input-group',
+		'tooltip' => array(
+			'data-title' => __('Search'),
+			'data-placement' => 'left',
+		),
+		'after' => '<span class="input-group-btn">'.$this->Form->button('Search', array(
+			'class' => 'btn btn-info',
+		)).'</span>'
+	));
+	echo $this->Form->end();
 ?>
-<div id="block-<?php echo $b['id']; ?>" class="<?php echo $class; ?>">
-<?php if ($b['show_title'] == 1) { ?>
-	<h3><?php echo $b['title']; ?></h3>
-<?php } ?>
-	<div class="block-body">
-		<form id="searchform" method="post" action="javascript: document.location.href=''+Croogo.basePath+'search/q:'+encodeURI($('#searchform #q').val());" class="form-search">
-		<?php
-			$qValue = null;
-			if (isset($this->params['named']['q'])) {
-				$qValue = $this->params['named']['q'];
-			}
-
-			$out = $this->Form->input('q', array(
-				'label' => false,
-				'name' => 'q',
-				'value' => $qValue,
-				'class' => 'form-control',
-				'placeholder' => __('Search'),
-				'div' => 'input-group',
-				'tooltip' => array(
-					'data-title' => __('Search'),
-					'data-placement' => 'left',
-				),
-				'after' => '<span class="input-group-btn">'.$this->Form->button('Search', array(
-
-					'class' => 'btn btn-info',
-				)).'</span>'
-			));
-
-			echo $this->Html->div(false, $out);
-		?>
-		</form>
-	</div>
-</div>


### PR DESCRIPTION
This PR covers two issues:

1) The $block code should not be necessary because the block in Croogo already does this. See the attached screenshot of how the form is double wrapped.

2) There have been security updates especially in the form generation and processing (I think that was in Croogo, but it might have been in Cake), so your custom built form was not being handled properly by Croogo. The resulting form still has the look and feel of your original.

<img width="1207" alt="screen shot 2016-10-24 at 4 35 44 pm" src="https://cloud.githubusercontent.com/assets/4733342/19666154/5c5fce08-9a0e-11e6-9076-5e0bf481319d.png">
